### PR TITLE
Fixed the type of parent

### DIFF
--- a/src/createjs/easeljs/DisplayObject.hx
+++ b/src/createjs/easeljs/DisplayObject.hx
@@ -18,7 +18,7 @@ extern class DisplayObject {
 	public var id:Float;
 	public var mouseEnabled:Bool;
 	public var name:String;
-	public var parent:DisplayObject;
+	public var parent:Container;
 	public var regX:Float;
 	public var regY:Float;
 	public var rotation:Float;


### PR DESCRIPTION
From the latest DisplayObject.js

> - @property parent
> - @final
> - @type {Container}

parent.removeChild(this); would work with this change.
