### PR TITLE
Fixed wrong type and added missing type on parameter with default value

### DIFF
--- a/createjs/easeljs/ButtonHelper.hx
+++ b/createjs/easeljs/ButtonHelper.hx
@@ -3,12 +3,12 @@ package createjs.easeljs;
 @:native("createjs.ButtonHelper")
 extern class ButtonHelper {
 
-	public function new(target:DisplayObject, ?outLabel:String = "out", ?overLabel:String = "over", ?downLabel = "down", ?play:Bool = false, ?hitArea:DisplayObject = null, ?hitLabel:String = null):Void;
+	public function new(target:DisplayObject, ?outLabel:String = "out", ?overLabel:String = "over", ?downLabel:String = "down", ?play:Bool = false, ?hitArea:DisplayObject = null, ?hitLabel:String = null):Void;
 	public function setEnabled(value:Bool):Void;
 	public function toString():String;
 	public var downLabel:Dynamic;
 	public var outLabel:Dynamic;
 	public var overLabel:Dynamic;
-	public var play:Boolean;
+	public var play:Bool;
 	public var target:DisplayObject;
 }


### PR DESCRIPTION
This change makes it possible to compile Haxe code that includes ButtonHelper.hx.
