### PR TITLE
stage update event RAF fix

### DIFF
--- a/createjs/easeljs/Stage.hx
+++ b/createjs/easeljs/Stage.hx
@@ -9,7 +9,7 @@ extern class Stage extends Container {
 	public function enableDOMEvents(?enable:Bool = true):Void;
 	public function enableMouseOver(?frequency:Float = 20):Void;
 	public function toDataURL(backgroundColor:String, mimeType:String):String;
-	public function update():Void;
+	public function update(?eventObj:Dynamic):Void;
 
 	public var autoClear:Bool;
 	public var canvas:Dynamic;


### PR DESCRIPTION
http://community.createjs.com/discussions/easeljs/4349-framerate-of-sprite-doesnt-change-and-framerate-of-stage-doesnt-change-in-raf-mode

Passing the event into the stage.update allows children to manage their own framerate.  Without it, they just run at full speed.